### PR TITLE
add missing error log

### DIFF
--- a/src/get-ca-config.ts
+++ b/src/get-ca-config.ts
@@ -63,6 +63,7 @@ export const getCodeArtifactConfig = async (
     if (e instanceof AggregateError) throw e;
 
     if (isAWSError(e)) {
+      console.error(e);
       errors.push(getError('EAWSSDK', { message: e.message, name: e.name }));
     } else {
       console.error(e);

--- a/src/get-ca-config.ts
+++ b/src/get-ca-config.ts
@@ -65,6 +65,7 @@ export const getCodeArtifactConfig = async (
     if (isAWSError(e)) {
       errors.push(getError('EAWSSDK', { message: e.message, name: e.name }));
     } else {
+      console.error(e);
       errors.push(
         getError('EAWSSDK', {
           name: 'UnknownException',


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
Added missing error log for an unexpected exception (it's is currently being "swallowed")


Original error (before the console.error addition):
```
[9:23:01 PM] [semantic-release] › ✘  Failed step "verifyConditions" of plugin "semantic-release-codeartifact"
[9:23:01 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
[9:23:01 PM] [semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry https://xxxx[35](https://github.com/project/actions/runs/12420987459/job/34679685927#step:6:36)7.d.codeartifact.us-east-2.amazonaws.com/
[9:23:01 PM] [semantic-release] [@semantic-release/npm] › ℹ  Reading npm config from /home/runner/work/project/.npmrc
[9:23:01 PM] [semantic-release] [@semantic-release/npm] › ℹ  Wrote NPM_TOKEN to /tmp/560257e687fbf296cf47dc9fbe57845b/.npmrc
[9:23:01 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
[9:23:01 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/github"
[9:23:01 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication (https://api.github.com)
[9:23:01 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/github"
[9:23:01 PM] [semantic-release] › ✘  An error occurred while running semantic-release: AggregateError: 
    SemanticReleaseError: AWS SDK Error
        at getError (/home/runner/work/project/node_modules/semantic-release-codeartifact/lib/src/get-error.js:11:12)
        at /home/runner/work/project/node_modules/semantic-release-codeartifact/lib/src/get-ca-config.js:63:[50](https://github.com/xxx/project/actions/runs/12420987459/job/34679685927#step:6:51)
        at Generator.throw (<anonymous>)
        at rejected (/home/runner/work/project/node_modules/semantic-release-codeartifact/lib/src/get-ca-config.js:6:65)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at /home/runner/work/project/node_modules/semantic-release-codeartifact/lib/src/get-ca-config.js:73:15
    at Generator.throw (<anonymous>)
    at rejected (/home/runner/work/project/node_modules/semantic-release-codeartifact/lib/src/get-ca-config.js:6:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  pluginName: 'semantic-release-codeartifact'
```

The added log (new information not available above):
```
ResourceNotFoundException: Domain not found. Domain '****' owned by account '****' does not exist.
    at de_ResourceNotFoundExceptionRes (/home/runner/work/project/node_modules/@aws-sdk/client-codeartifact/dist-cjs/index.js:2139:21)
    at de_CommandError (/home/runner/work/project/node_modules/@aws-sdk/client-codeartifact/dist-cjs/index.js:2069:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /home/runner/work/project/node_modules/@smithy/middleware-serde/dist-cjs/index.js:35:20
    at async /home/runner/work/project/node_modules/@smithy/core/dist-cjs/index.js:168:18
    at async /home/runner/work/project/node_modules/@smithy/middleware-retry/dist-cjs/index.js:[32](https://github.com/project/actions/runs/12420987459/job/34679685927#step:6:33)0:38
    at async /home/runner/work/project/node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22 {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 404,
    requestId: '7bd611e4-f98c-4373-a95f-b9020638380a',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  resourceId: 'xxxxx',
  resourceType: 'domain'
}
```


<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
